### PR TITLE
fix: require(...) is not a function

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,5 +7,7 @@ export default <Options>{
   clean: true,
   format: ['cjs', 'esm'],
   dts: true,
+  cjsInterop: true,
+  splitting: true,
   onSuccess: 'npm run build:fix',
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently cannot import the plugin into a CJS file because the module is exported as module.exports.default rather than simply module.exports.
![cjs-error](https://github.com/unplugin/unplugin-starter/assets/104537923/2fb13d85-6b59-4ce8-b1f7-e418f983ce5f)

### Linked Issues

Related Discussions: https://github.com/egoist/tsup/issues/572#issuecomment-1927105408

### Additional context

Here's an example of a successful repair: [fix-cjs-example](https://github.com/RuSenLi/unplugin-starter/tree/fix-cjs-example)
